### PR TITLE
wapm.io manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,9 +1247,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.0"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
+checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http",
  "hyper",
@@ -1551,7 +1557,7 @@ dependencies = [
  "ahash 0.8.0",
  "ammonia",
  "atty",
- "base64",
+ "base64 0.13.0",
  "csv",
  "elasticlunr-rs",
  "filetime",
@@ -2553,7 +2559,7 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd39bc6cdc9355ad1dc5eeedefee696bb35c34caf21768741e81826c0bbd7225"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "indexmap",
  "line-wrap",
  "serde",
@@ -2825,7 +2831,7 @@ version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "bytes 1.2.1",
  "encoding_rs",
  "futures-core",
@@ -2906,9 +2912,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.6"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
 dependencies = [
  "log",
  "ring",
@@ -2918,11 +2924,11 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64",
+ "base64 0.21.0",
 ]
 
 [[package]]
@@ -3915,9 +3921,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.4"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,8 @@ libs = { path = "components/libs" }
 same-file = "1"
 
 [features]
-default = ["rust-tls", "serve"]
+default = ["rust-tls", "serve", "reqwest"]
+reqwest = ["libs/reqwest"]
 rust-tls = ["libs/rust-tls"]
 native-tls = ["libs/native-tls"]
 indexing-zh = ["libs/indexing-zh"]

--- a/README-wapm.md
+++ b/README-wapm.md
@@ -1,0 +1,7 @@
+# [Zola](https://www.getzola.org/) modified for WASM by [dstaley](https://github.com/dstaley/zola/tree/wasm)
+
+Usage:
+```bash
+cd to_your_zola_page
+wasmer run https://wapm.io/dstaley/zola --dir=. -- --root=/ build
+```

--- a/components/libs/Cargo.toml
+++ b/components/libs/Cargo.toml
@@ -47,7 +47,7 @@ webp = "0.2"
 
 [features]
 # TODO: fix me, it doesn't pick up the reqwuest feature if not set as default
-default = ["rust-tls", "reqwest", "rayon"]
+default = ["rayon"]
 rust-tls = ["reqwest/rustls-tls"]
 native-tls = ["reqwest/default-tls"]
 indexing-zh = ["elasticlunr-rs/zh"]

--- a/components/templates/src/global_fns/load_data.rs
+++ b/components/templates/src/global_fns/load_data.rs
@@ -6,6 +6,7 @@ use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
 use libs::csv::Reader;
+#[cfg(feature = "serve")]
 use libs::reqwest::header::{HeaderMap, HeaderName, HeaderValue, CONTENT_TYPE};
 #[cfg(feature = "serve")]
 use libs::reqwest::{blocking::Client, header};
@@ -192,6 +193,7 @@ fn get_output_format_from_args(
     }
 }
 
+#[cfg(feature = "serve")]
 fn add_headers_from_args(header_args: Option<Vec<String>>) -> Result<HeaderMap> {
     let mut headers = HeaderMap::new();
     if let Some(header_args) = header_args {

--- a/wapm.toml
+++ b/wapm.toml
@@ -1,0 +1,20 @@
+[package]
+name = "dstaley/zola"
+version = "0.0.0-1"
+description = "A fast static site generator in a single binary with everything built-in. "
+license = "MIT"
+repository = "https://github.com/dstaley/zola/releases/tag/v0.0.0"
+homepage = "https://www.getzola.org/"
+readme = "README-wapm.md"
+
+[[module]]
+name = "zola"
+source = "js/zola.wasm"
+abi = "wasi"
+
+[module.interfaces]
+wasi = "0.1.0-unstable"
+
+[[command]]
+name = "zola"
+module = "zola"


### PR DESCRIPTION
Hey, would you be ok with me publishing this wasm file to [wapm.io](https://wapm.io/)? That would allow anyone with wasmer installed to run zola easily.

In fact, you can also try that directly from the file [attached](https://github.com/dstaley/zola/files/10425256/zola.tar.gz) to this post:
```bash
wasmer run https://github.com/dstaley/zola/files/10425256/zola.tar.gz --dir=. -- --root=/ build
```
but alas, publishing to wapm.io looks nicer.

(Normally, this would be an issue, but issues are disabled here and I have neither twitter nor mastodon, hence no other contact option. Of course, you could also publish to wapm yourself based on the files in this PR, if you want.)